### PR TITLE
rAdd iframe favicon and title extraction for ZIM pages

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,11 +7,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:4000',
         changeOrigin: true
       },
       '/content': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:4000',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
- Extract favicon and page title from iframe content in ZimViewer
- Extract favicon and page title from iframe content in ZimArticle
- Update favicon and browser tab title dynamically as user navigates
- Handle cross-origin restrictions with fallback to ZIM metadata
- Fix vite.config.js proxy to use correct port 4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)